### PR TITLE
GetValidationResults 有空能是属性为空的情况，如果在执行rule 可能就直接报错了。感觉实体验证无法通过，就不用去验证业务

### DIFF
--- a/src/Util/Domains/DomainBase.cs
+++ b/src/Util/Domains/DomainBase.cs
@@ -105,6 +105,10 @@ namespace Util.Domains {
         private ValidationResultCollection GetValidationResults() {
             var result = DataAnnotationValidation.Validate( this );
             Validate( result );
+
+            if (!result.IsValid)
+                return result;
+
             foreach( var rule in _rules )
                 result.Add( rule.Validate() );
             return result;


### PR DESCRIPTION
如果在执行rule 可能就直接报错了。感觉实体验证无法通过，就不用去验证业务