### PR TITLE
repair html attribute find

### DIFF
--- a/src/Util.Webs/Razors/RouteAnalyzer.cs
+++ b/src/Util.Webs/Razors/RouteAnalyzer.cs
@@ -82,8 +82,8 @@ namespace Util.Webs.Razors
         private void SetHtmlInfo(RouteInformation routeInformation,
             ControllerActionDescriptor controllerActionDescriptor)
         {
-            var htmlAttribute = controllerActionDescriptor.ControllerTypeInfo.GetCustomAttribute<HtmlAttribute>() ??
-                                controllerActionDescriptor.MethodInfo.GetCustomAttribute<HtmlAttribute>();
+            var htmlAttribute = controllerActionDescriptor.MethodInfo.GetCustomAttribute<HtmlAttribute>() ??
+                                controllerActionDescriptor.ControllerTypeInfo.GetCustomAttribute<HtmlAttribute>();
             if (htmlAttribute == null)
                 return;
             routeInformation.FilePath = htmlAttribute.Path;


### PR DESCRIPTION
Repair route analyzer html attribute find. The original way to prioritize the controller and then to the method. Now the preferred method and then to the controller.