### PR TITLE
修复 Exceptionless 多次输出日志问题

### DIFF
--- a/src/Util.Logs/Contents/LogContent.cs
+++ b/src/Util.Logs/Contents/LogContent.cs
@@ -121,5 +121,9 @@ namespace Util.Logs.Contents {
         /// 异常
         /// </summary>
         public Warning Exception { get; set; }
+        /// <summary>
+        /// 排序
+        /// </summary>
+        public int Order { get; set; }
     }
 }

--- a/src/Util.Logs/Exceptionless/ExceptionlessProvider.cs
+++ b/src/Util.Logs/Exceptionless/ExceptionlessProvider.cs
@@ -137,7 +137,7 @@ namespace Util.Logs.Exceptionless {
         /// 设置跟踪号
         /// </summary>
         private void SetReferenceId( EventBuilder builder, ILogContent content ) {
-            builder.SetReferenceId( content.TraceId );
+            builder.SetReferenceId( $"{content.TraceId}-{content.Order}" );
         }
 
         /// <summary>

--- a/src/Util/Logs/Abstractions/ILogContent.cs
+++ b/src/Util/Logs/Abstractions/ILogContent.cs
@@ -58,5 +58,9 @@ namespace Util.Logs.Abstractions {
         /// 异常消息
         /// </summary>
         Warning Exception { get; set; }
+        /// <summary>
+        /// 排序
+        /// </summary>
+        int Order { get; set; }
     }
 }

--- a/src/Util/Logs/Abstractions/ILogContext.cs
+++ b/src/Util/Logs/Abstractions/ILogContext.cs
@@ -29,5 +29,13 @@ namespace Util.Logs.Abstractions {
         /// 请求地址
         /// </summary>
         string Url { get; }
+        /// <summary>
+        /// 排序
+        /// </summary>
+        int Order { get; }
+        /// <summary>
+        /// 更新上下文
+        /// </summary>
+        void UpdateContext();
     }
 }

--- a/src/Util/Logs/Core/LogBase.cs
+++ b/src/Util/Logs/Core/LogBase.cs
@@ -78,6 +78,7 @@ namespace Util.Logs.Core {
             content.Browser = Context.Browser;
             content.Url = Context.Url;
             content.UserId = Session.UserId;
+            content.Order = Context.Order;
         }
 
         /// <summary>
@@ -112,6 +113,7 @@ namespace Util.Logs.Core {
                 Provider.WriteLog( level, content );
             }
             finally {
+                Context.UpdateContext();
                 content = null;
             }
         }

--- a/src/Util/Logs/Core/LogContext.cs
+++ b/src/Util/Logs/Core/LogContext.cs
@@ -54,6 +54,21 @@ namespace Util.Logs.Core {
         /// 请求地址
         /// </summary>
         public string Url => GetInfo().Url;
+        /// <summary>
+        /// 排序
+        /// </summary>
+        public int Order => GetInfo().Order;
+
+        /// <summary>
+        /// 更新上下文
+        /// </summary>
+        public void UpdateContext()
+        {
+            if (_info != null)
+            {
+                _info.Order += 1;
+            }
+        }
 
         /// <summary>
         /// 获取日志上下文信息

--- a/src/Util/Logs/Core/NullLogContext.cs
+++ b/src/Util/Logs/Core/NullLogContext.cs
@@ -34,5 +34,16 @@ namespace Util.Logs.Core {
         /// 请求地址
         /// </summary>
         public string Url => string.Empty;
+        /// <summary>
+        /// 排序
+        /// </summary>
+        public int Order => 0;
+
+        /// <summary>
+        /// 更新上下文
+        /// </summary>
+        public void UpdateContext()
+        {
+        }
     }
 }

--- a/src/Util/Logs/Internal/LogContextInfo.cs
+++ b/src/Util/Logs/Internal/LogContextInfo.cs
@@ -34,5 +34,10 @@ namespace Util.Logs.Internal {
         /// 请求地址
         /// </summary>
         public string Url { get; set; }
+
+        /// <summary>
+        /// 排序
+        /// </summary>
+        public int Order { get; set; }
     }
 }


### PR DESCRIPTION
由于Exceptionless 一个跟踪号只能使用一次，因此需要对日志进行顺序处理，实现一次请求中，可多次输出日志