### PR TITLE
reactor: 新增日志标识，原有跟踪号用于查询使用

### DIFF
--- a/src/Util.Logs/Contents/LogContent.cs
+++ b/src/Util.Logs/Contents/LogContent.cs
@@ -26,6 +26,10 @@ namespace Util.Logs.Contents {
         /// </summary>
         public string Level { get; set; }
         /// <summary>
+        /// 日志标识
+        /// </summary>
+        public string LogId { get; set; }
+        /// <summary>
         /// 跟踪号
         /// </summary>
         public string TraceId { get; set; }

--- a/src/Util.Logs/Exceptionless/ExceptionlessProvider.cs
+++ b/src/Util.Logs/Exceptionless/ExceptionlessProvider.cs
@@ -61,6 +61,7 @@ namespace Util.Logs.Exceptionless {
             SetSource( builder, content );
             SetReferenceId( builder, content );
             AddProperties( builder, content as ILogConvert );
+            AddTags(builder, content);
             builder.Submit();
         }
 
@@ -75,9 +76,12 @@ namespace Util.Logs.Exceptionless {
         /// 创建事件生成器
         /// </summary>
         private EventBuilder CreateBuilder( LogLevel level, ILogContent content ) {
-            if( content.Exception != null )
-                return _client.CreateException( content.Exception );
-            return _client.CreateLog( GetMessage( content ), ConvertTo( level ) );
+            if (content.Exception != null && (level == LogLevel.Error || level == LogLevel.Critical))
+                return _client.CreateException(content.Exception);
+            var builder = _client.CreateLog(GetMessage(content), ConvertTo(level));
+            if (content.Exception != null && level == LogLevel.Warning)
+                builder.SetException(content.Exception);
+            return builder;
         }
 
         /// <summary>
@@ -89,7 +93,7 @@ namespace Util.Logs.Exceptionless {
                 return caption.Caption;
             if( content.Content.Length > 0 )
                 return content.Content.ToString();
-            return content.TraceId;
+            return content.LogId;
         }
 
         /// <summary>
@@ -135,9 +139,7 @@ namespace Util.Logs.Exceptionless {
         /// <summary>
         /// 设置跟踪号
         /// </summary>
-        private void SetReferenceId( EventBuilder builder, ILogContent content ) {
-            builder.SetReferenceId( content.TraceId );
-        }
+        private void SetReferenceId( EventBuilder builder, ILogContent content ) => builder.SetReferenceId($"{content.LogId}");
 
         /// <summary>
         /// 添加属性集合
@@ -151,6 +153,11 @@ namespace Util.Logs.Exceptionless {
                 builder.SetProperty( $"{GetLine()}. {parameter.Text}", parameter.Value );
             }
         }
+
+        /// <summary>
+        /// 添加标签
+        /// </summary>
+        private void AddTags(EventBuilder builder, ILogContent content) => builder.AddTags(content.Level, content.LogName, content.TraceId);
 
         /// <summary>
         /// 获取行号

--- a/src/Util.Logs/Exceptionless/LogContent.cs
+++ b/src/Util.Logs/Exceptionless/LogContent.cs
@@ -11,6 +11,7 @@ namespace Util.Logs.Exceptionless {
         /// </summary>
         public List<Item> To() {
             return new List<Item> {
+                { new Item( LogResource.LogId, LogId,0) },
                 { new Item( LogResource.LogName, LogName,1) },
                 { new Item(LogResource.TraceId, TraceId,2) },
                 { new Item(LogResource.OperationTime, OperationTime,3) },

--- a/src/Util.Logs/Formats/ContentFormat.cs
+++ b/src/Util.Logs/Formats/ContentFormat.cs
@@ -82,7 +82,7 @@ namespace Util.Logs.Formats {
         protected void Line1( StringBuilder result, LogContent content, ref int line ) {
             AppendLine( result, content, ( r, c ) => {
                 r.AppendFormat( "{0}: {1} >> ", c.Level, c.LogName );
-                r.AppendFormat( "{0}: {1}   ", LogResource.TraceId, c.TraceId );
+                r.AppendFormat( "{0}: {1}   ", LogResource.LogId, c.LogId );
                 r.AppendFormat( "{0}: {1}   ", LogResource.OperationTime, c.OperationTime );
                 if( string.IsNullOrWhiteSpace( c.Duration ) )
                     return;

--- a/src/Util.Logs/Properties/LogResource.Designer.cs
+++ b/src/Util.Logs/Properties/LogResource.Designer.cs
@@ -19,7 +19,7 @@ namespace Util.Logs.Properties {
     // 类通过类似于 ResGen 或 Visual Studio 的工具自动生成的。
     // 若要添加或移除成员，请编辑 .ResX 文件，然后重新运行 ResGen
     // (以 /str 作为命令选项)，或重新生成 VS 项目。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class LogResource {
@@ -147,6 +147,15 @@ namespace Util.Logs.Properties {
         public static string Host {
             get {
                 return ResourceManager.GetString("Host", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 日志标识 的本地化字符串。
+        /// </summary>
+        public static string LogId {
+            get {
+                return ResourceManager.GetString("LogId", resourceCulture);
             }
         }
         

--- a/src/Util.Logs/Properties/LogResource.resx
+++ b/src/Util.Logs/Properties/LogResource.resx
@@ -147,6 +147,9 @@
   <data name="Host" xml:space="preserve">
     <value>主机</value>
   </data>
+  <data name="LogId" xml:space="preserve">
+    <value>日志标识</value>
+  </data>
   <data name="LogName" xml:space="preserve">
     <value>日志名称</value>
   </data>

--- a/src/Util/Logs/Abstractions/ILogContent.cs
+++ b/src/Util/Logs/Abstractions/ILogContent.cs
@@ -15,6 +15,10 @@ namespace Util.Logs.Abstractions {
         /// </summary>
         string Level { get; set; }
         /// <summary>
+        /// 日志标识
+        /// </summary>
+        string LogId { get; set; }
+        /// <summary>
         /// 跟踪号
         /// </summary>
         string TraceId { get; set; }

--- a/src/Util/Logs/Abstractions/ILogContext.cs
+++ b/src/Util/Logs/Abstractions/ILogContext.cs
@@ -8,6 +8,10 @@ namespace Util.Logs.Abstractions {
     [Ignore]
     public interface ILogContext {
         /// <summary>
+        /// 日志标识
+        /// </summary>
+        string LogId { get; }
+        /// <summary>
         /// 跟踪号
         /// </summary>
         string TraceId { get; }

--- a/src/Util/Logs/Core/LogBase.cs
+++ b/src/Util/Logs/Core/LogBase.cs
@@ -69,6 +69,7 @@ namespace Util.Logs.Core {
         /// <param name="content">日志内容</param>
         protected virtual void Init( TContent content ) {
             content.LogName = Provider.LogName;
+            content.LogId = Context.LogId;
             content.TraceId = Context.TraceId;
             content.OperationTime = DateTime.Now.ToMillisecondString();
             content.Duration = Context.Stopwatch.Elapsed.Description();

--- a/src/Util/Logs/Core/LogContext.cs
+++ b/src/Util/Logs/Core/LogContext.cs
@@ -35,9 +35,14 @@ namespace Util.Logs.Core {
         public virtual IContext Context => _context ?? ( _context = ContextFactory.Create() );
 
         /// <summary>
+        /// 日志标识
+        /// </summary>
+        public string LogId => $"{GetInfo().TraceId}-{++_orderId}";
+
+        /// <summary>
         /// 跟踪号
         /// </summary>
-        public string TraceId => $"{GetInfo().TraceId}-{++_orderId}";
+        public string TraceId => $"{GetInfo().TraceId}";
 
         /// <summary>
         /// 计时器

--- a/src/Util/Logs/Core/NullLogContext.cs
+++ b/src/Util/Logs/Core/NullLogContext.cs
@@ -11,6 +11,10 @@ namespace Util.Logs.Core {
         /// </summary>
         public static readonly ILogContext Instance = new NullLogContext();
         /// <summary>
+        /// 日志标识
+        /// </summary>
+        public string LogId => string.Empty;
+        /// <summary>
         /// 跟踪号
         /// </summary>
         public string TraceId => string.Empty;


### PR DESCRIPTION
优化日志内部属性，新增日志标识，便于Exceptionless查询使用。
在Exceptionless查询 只需使用 `tags: 跟踪号`，即可查询出相关跟踪号的日志出来
