### PR TITLE
HmacSha256允许使用key加密空值

### DIFF
--- a/src/Util.Security/Helpers/Encrypt.cs
+++ b/src/Util.Security/Helpers/Encrypt.cs
@@ -260,9 +260,15 @@ public static class Encrypt {
     /// <param name="value">值</param>
     /// <param name="key">密钥</param>
     /// <param name="encoding">字符编码</param>
-    public static string HmacSha256( string value, string key, Encoding encoding = null ) {
+    /// <param name="allowEmptyValue">允许空value值</param>
+    public static string HmacSha256( string value, string key, Encoding encoding = null, bool allowEmptyValue = false ) {
         if ( value.IsEmpty() || key.IsEmpty() )
-            return string.Empty;
+        {
+            if ( !allowEmptyValue )
+                return string.Empty;
+            value ??= "";
+            value = value.Replace( " ", "" );
+        }
         encoding ??= Encoding.UTF8;
         var sha256 = new HMACSHA256( Encoding.ASCII.GetBytes( key ) );
         var hash = sha256.ComputeHash( encoding.GetBytes( value ) );

--- a/test/Util.Security.Tests/Helpers/EncryptTest.cs
+++ b/test/Util.Security.Tests/Helpers/EncryptTest.cs
@@ -137,6 +137,19 @@ public class EncryptTest {
         Assert.Equal( result, Encrypt.HmacSha256( input, key ) );
     }
 
+    [Theory]
+    [InlineData(null, "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0")]
+    [InlineData("", "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0")]
+    [InlineData(" ", "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0")]
+    [InlineData("        ", "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0")]
+    [InlineData("a", "780c3db4ce3de5b9e55816fba98f590631d96c075271b26976238d5f4444219b")]
+    [InlineData("中国", "dde7619d5465b73d94c18e6d979ab3dd9e478cb91b00d312ece776b282b7e0a9")]
+    public void TestHmacSha256AllowEmptyValue( string input, string result ) {
+        var key = "key";
+        _output.WriteLine( $"input:{input},result:{Encrypt.HmacSha256( input, key, allowEmptyValue: true )}" );
+        Assert.Equal( result, Encrypt.HmacSha256( input, key, allowEmptyValue: true ) );
+    }
+
     /// <summary>
     /// 测试Rsa签名和验签
     /// </summary>


### PR DESCRIPTION
微信小程序开发有这样的使用场景：  

> signature	string	是	用***sessionkey对空字符串签名***得到的结果。session_key可通过code2Session接口获得。

[官网API链接](https://developers.weixin.qq.com/miniprogram/dev/OpenApiDoc/user-info/internet/getUserEncryptKey.html)